### PR TITLE
allow named variables as arguments instead of DeBruijn indices

### DIFF
--- a/lambda/debruijn-lambda.rkt
+++ b/lambda/debruijn-lambda.rkt
@@ -1,0 +1,29 @@
+#lang racket
+(require (for-syntax syntax/parse)
+         (rename-in "lifted-lambda.rkt"
+                   [prog lifted-prog]))
+
+(provide prog)
+
+(define-syntax (prog stx)
+  (syntax-parse stx
+    [(prog backend expr)
+     (define-values [main blocks] (lift-lambdas #'expr))
+     #`(lifted-prog backend #,main . #,blocks)]))
+
+(define-for-syntax (lift-lambdas expr)
+  (syntax-parse expr #:literals (lambda print)
+    [(lambda body)
+     #:do [(define-values [body-expr body-blocks] (lift-lambdas #'body))]
+     #:with lambda-name (car (generate-temporaries '(lambda)))
+     (values #'lambda-name #`((lambda-name #,body-expr) . #,body-blocks))]
+    [(fun arg)
+     #:do [(define-values [fun-expr fun-blocks] (lift-lambdas #'fun))
+           (define-values [arg-expr arg-blocks] (lift-lambdas #'arg))]
+     #:with (arg-block ...) arg-blocks
+     #:with (fun-block ...) fun-blocks
+     (values #`(#,fun-expr #,arg-expr)
+             #'(arg-block ... fun-block ...))]
+    [n:nat (values #'n #'())]
+    [str:str (values #'str #'())]
+    [print (values #'print #'())]))

--- a/lambda/lambda.rkt
+++ b/lambda/lambda.rkt
@@ -1,29 +1,44 @@
 #lang racket
-(require (for-syntax syntax/parse)
-         (rename-in "lifted-lambda.rkt"
-                   [prog lifted-prog]))
+(require (for-syntax racket/match syntax/parse)
+         (rename-in "debruijn-lambda.rkt"
+                    [prog debruijn-prog]))
 
 (provide prog)
 
 (define-syntax (prog stx)
   (syntax-parse stx
     [(prog backend expr)
-     (define-values [main blocks] (lift-lambdas #'expr))
-     #`(lifted-prog backend #,main . #,blocks)]))
+     #:with debruijn-expr (convert-debruijn-indices #'expr empty-ids)
+     #`(debruijn-prog backend debruijn-expr)]))
 
-(define-for-syntax (lift-lambdas expr)
-  (syntax-parse expr #:literals (lambda print)
-    [(lambda body)
-     #:do [(define-values [body-expr body-blocks] (lift-lambdas #'body))]
-     #:with lambda-name (car (generate-temporaries '(lambda)))
-     (values #'lambda-name #`((lambda-name #,body-expr) . #,body-blocks))]
-    [(fun arg)
-     #:do [(define-values [fun-expr fun-blocks] (lift-lambdas #'fun))
-           (define-values [arg-expr arg-blocks] (lift-lambdas #'arg))]
-     #:with (arg-block ...) arg-blocks
-     #:with (fun-block ...) fun-blocks
-     (values #`(#,fun-expr #,arg-expr)
-             #'(arg-block ... fun-block ...))]
-    [n:nat (values #'n #'())]
-    [str:str (values #'str #'())]
-    [print (values #'print #'())]))
+(begin-for-syntax
+  ;; An IdEnv is one of:
+  ;; - empty-ids
+  ;; - (extend-ids Id IdEnv)
+  (define empty-ids '())
+  (define extend-ids cons)
+
+  ;; find-index : IdEnv Id Natural -> Natural
+  (define (find-index ids x i)
+    (match ids
+      ['() (raise-syntax-error #f "unbound identifier" x)]
+      [(cons id ids)
+       (if (bound-identifier=? id x)
+           i
+           (find-index ids x (add1 i)))]))
+  
+  ;; convert-debruijn-indices : Stx IdEnv -> Stx
+  (define (convert-debruijn-indices stx ids)
+    (syntax-parse stx #:literals (lambda print)
+      [print #'print]
+      [x:id (find-index ids #'x 0)]
+      [(lambda (x:id) body:expr)
+       #:with debruijn-body (convert-debruijn-indices #'body (extend-ids #'x ids))
+       #'(lambda debruijn-body)]
+      [(fun:expr arg:expr)
+       #:with debruijn-fun (convert-debruijn-indices #'fun ids)
+       #:with debruijn-arg (convert-debruijn-indices #'arg ids)
+       #'(debruijn-fun debruijn-arg)]
+      [n:nat #'n]
+      [str:str #'str]
+      )))

--- a/test/lambda-mips.rkt
+++ b/test/lambda-mips.rkt
@@ -9,10 +9,10 @@
 ;; test cases
 (test-case "test stuff"
   (define assem
-    (prog mips ((((lambda (lambda (lambda (2 "test"))))
-                  (lambda (print 0)))
-                 (lambda 0))
-                (lambda (print 0)))))
+    (prog mips ((((lambda (x) (lambda (y) (lambda (z) (x "test"))))
+                  (lambda (x) (print x)))
+                 (lambda (x) x))
+                (lambda (x) (print x)))))
   (check-equal? (run-mips assem) "test"))
 
 (test-case "(print \"test\\n\")"
@@ -23,9 +23,9 @@
   ;; (((lambda (lambda (1 1))) (lambda 0)) (lambda 0))
   ;; should be an identity function
   (define assem
-    (prog mips (print ((((lambda (lambda (1 1))) (lambda 0)) (lambda 0)) "a string"))))
+    (prog mips (print ((((lambda (x) (lambda (y) (x x))) (lambda (x) x)) (lambda (x) x)) "a string"))))
   (check-equal? (run-mips assem) "a string"))
 
 (test-case "not a function"
-  (define assem (prog mips ("test" (lambda 0))))
+  (define assem (prog mips ("test" (lambda (x) x))))
   (check-equal? (run-mips assem) "attempted to call a non-function"))


### PR DESCRIPTION
So that you can write `(lambda (x) (lambda (y) (x y))` instead of `(lambda (lambda (1 0)))`.
